### PR TITLE
重改命令行模式代码并增加4个参数

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "author": "liuguanyu",
   "license": "MIT",
   "dependencies": {
+    "commander": "^2.8.1",
     "crypto": "0.0.3",
     "http": "0.0.0",
     "immutable": "^3.7.4",

--- a/util/download.js
+++ b/util/download.js
@@ -1,0 +1,42 @@
+var PLine = require("../pline/pline.js");
+
+function Download(folder, thread) {
+	this.folder = folder;
+	this.thread = thread;
+}
+Download.prototype.pipe = function() {
+	return new Promise(function(resolve) {
+		var data = "";
+		process.stdin.resume(); //Compatible with old stream
+		process.stdin.setEncoding("utf-8");
+		process.stdin.on("data", function(chunk) { data += chunk.toString() });
+		process.stdin.on("end", function() { resolve(data.split("\n")) });
+	}).then(this.download);
+}
+Download.prototype.file = function(file) {
+	return new Promise(function(resolve, reject) {
+		require("fs").readFile(file, function(err, data) {
+			if(err) reject(err);
+			resolve(data.toString().split("\n"));
+		})
+	}).then(this.download).catch(function(error) { console.log(error) });
+}
+Download.prototype.url = function(url) {
+	return this.download([url]);
+}
+Download.prototype.download = function(urls) {
+	return urls.filter(function(el) { return el.trim() !== "" })
+		.forEach(function(url) {
+			(new PLine(url)).run();
+		})
+	// 	.map(function(url) { return new PLine(url) })
+	// 	.reduce(function(seq, el) {
+	// 	return seq.then(function() {
+	// 		el.run()
+	// 	})
+	// }, Promise.resolve()).then(function() {
+	// 	console.log("下载完毕");
+	// });
+}
+
+module.exports = function(folder, thread) { return new Download(folder, thread) }


### PR DESCRIPTION
命令行模式稍微改写了一下，使用了 Commander 模块，在 Win 和 Mac 下都测试了一遍，可以使用，具体可再测试。增加了 `file`, `url`, `download`, `thread` 四个参数，下载文件夹地址和进程数这两个参数可以配置但是暂时还不生效。
