### PR TITLE
增加自定义下载文件夹功能

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,4 @@
+{
+	"download": "./",
+	"thread": 5
+}

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node 
-var cli = require("commander");
+var cli = require("commander"),
+	fs = require("fs"),
+	path = require("path");
 
 cli.
 	allowUnknownOption().
@@ -10,15 +12,16 @@ cli.
 	option("-t, --thread [value]", "download thread number").
 	parse( process.argv );
 
-//线程数参数设置
-var thread = 5;
-if(cli.thread && typeof(cli.thread)=="string") thread = parseInt(cli.thread);
+// 载入配置
+var config = require("./config.json");
+if(cli.thread && typeof(cli.thread)=="string") config.thread = parseInt(cli.thread);
+if(cli.download && typeof(cli.download)=="string") config.download = cli.download;
+fs.writeFile(
+	path.resolve(__dirname,"config.json"), 
+	JSON.stringify(config, null, "\t")
+);
 
-//下载地址配置
-var folder = "./";
-if(cli.download && typeof(cli.download)=="string") folder = cli.download;
-
-var dispatch = require("./pline/dispatch.js")(folder, thread);
+var dispatch = require("./pline/dispatch.js")(config);
 //检测是否是管道
 if(!process.stdin.isTTY) return dispatch.pipe();
 

--- a/index.js
+++ b/index.js
@@ -18,11 +18,11 @@ if(cli.thread && typeof(cli.thread)=="string") thread = parseInt(cli.thread);
 var folder = "./";
 if(cli.download && typeof(cli.download)=="string") folder = cli.download;
 
-var download = require("./util/download.js")(folder, thread);
+var dispatch = require("./pline/dispatch.js")(folder, thread);
 //检测是否是管道
-if(!process.stdin.isTTY) return download.pipe();
+if(!process.stdin.isTTY) return dispatch.pipe();
 
 //非管道检测有下载列表，有下载URL，无下载列表和下载URL三种情况，优先级下载列表大于URL
-if(cli.file && typeof(cli.file)=="string") return download.file(cli.file);
-else if(cli.url && typeof(cli.url)=="string") return download.url(cli.url);
-else return download.file("./download.txt");
+if(cli.file && typeof(cli.file)=="string") return dispatch.file(cli.file);
+else if(cli.url && typeof(cli.url)=="string") return dispatch.url(cli.url);
+else return dispatch.file("./download.txt");

--- a/pline/dispatch.js
+++ b/pline/dispatch.js
@@ -1,10 +1,10 @@
-var PLine = require("../pline/pline.js");
+var PLine = require("./pline.js");
 
-function Download(folder, thread) {
+function Dispatch(folder, thread) {
 	this.folder = folder;
 	this.thread = thread;
 }
-Download.prototype.pipe = function() {
+Dispatch.prototype.pipe = function() {
 	return new Promise(function(resolve) {
 		var data = "";
 		process.stdin.resume(); //Compatible with old stream
@@ -13,7 +13,7 @@ Download.prototype.pipe = function() {
 		process.stdin.on("end", function() { resolve(data.split("\n")) });
 	}).then(this.download);
 }
-Download.prototype.file = function(file) {
+Dispatch.prototype.file = function(file) {
 	return new Promise(function(resolve, reject) {
 		require("fs").readFile(file, function(err, data) {
 			if(err) reject(err);
@@ -21,10 +21,10 @@ Download.prototype.file = function(file) {
 		})
 	}).then(this.download).catch(function(error) { console.log(error) });
 }
-Download.prototype.url = function(url) {
+Dispatch.prototype.url = function(url) {
 	return this.download([url]);
 }
-Download.prototype.download = function(urls) {
+Dispatch.prototype.download = function(urls) {
 	return urls.filter(function(el) { return el.trim() !== "" })
 		.forEach(function(url) {
 			(new PLine(url)).run();
@@ -39,4 +39,4 @@ Download.prototype.download = function(urls) {
 	// });
 }
 
-module.exports = function(folder, thread) { return new Download(folder, thread) }
+module.exports = function(folder, thread) { return new Dispatch(folder, thread) }

--- a/pline/dispatch.js
+++ b/pline/dispatch.js
@@ -1,8 +1,8 @@
 var PLine = require("./pline.js");
 
-function Dispatch(folder, thread) {
-	this.folder = folder;
-	this.thread = thread;
+function Dispatch(config) {
+	this.folder = config.download;
+	this.thread = config.thread;
 }
 Dispatch.prototype.pipe = function() {
 	return new Promise(function(resolve) {
@@ -25,18 +25,11 @@ Dispatch.prototype.url = function(url) {
 	return this.download([url]);
 }
 Dispatch.prototype.download = function(urls) {
+	var self = this;
 	return urls.filter(function(el) { return el.trim() !== "" })
 		.forEach(function(url) {
-			(new PLine(url)).run();
+			(new PLine(url, self.folder)).run();
 		})
-	// 	.map(function(url) { return new PLine(url) })
-	// 	.reduce(function(seq, el) {
-	// 	return seq.then(function() {
-	// 		el.run()
-	// 	})
-	// }, Promise.resolve()).then(function() {
-	// 	console.log("下载完毕");
-	// });
 }
 
-module.exports = function(folder, thread) { return new Dispatch(folder, thread) }
+module.exports = function(config) { return new Dispatch(config) }

--- a/pline/pline.js
+++ b/pline/pline.js
@@ -14,8 +14,9 @@ var getSiteNameByUrl = function (url){
 	return siteInfo[siteInfo.length - 2];
 };
 
-var PLine = function (url){
+var PLine = function (url, folder){
 	this.url = url;
+	this.workPath = folder;
 };
 
 PLine.prototype = {
@@ -31,8 +32,6 @@ PLine.prototype = {
 		console.log("正在下载：" + data.title);
 		console.log("总大小：" + util.spaceUtil.getSize(data.size));
 		console.log("分块数：" + data.urls.length);
-
-		this.workPath = path.resolve(__dirname, "..");
 
 		return util.downloadUtil.download(data.urls, data.site_postfix);
 	},
@@ -55,8 +54,7 @@ PLine.prototype = {
 				rets.push(el);
 			});
 
-			var finalFile = path.resolve(self.workPath + "/" + self.title + "." + postfix);
-
+			var finalFile = path.resolve( self.workPath, [self.title, postfix].join("."));
 			return transcoder.mergeAndTranscode(rets, finalFile);
 		});
 	},

--- a/util/util.js
+++ b/util/util.js
@@ -79,7 +79,7 @@ var fsUtil = {
 	    }
 
 	    fs.mkdirSync(dir);
-
+	    console.log(dir);
 	    return dir;
     }
 
@@ -117,7 +117,7 @@ var downloadUtil = {
 
 	download : function (urls, downloadPostfix, workPath){
 		if (typeof workPath === "undefined"){
-			workPath = path.resolve(__dirname, '..', (+new Date()) + '');
+			workPath = path.resolve(__dirname, '..', require("../config.json").download, (+new Date()) + '');
 		}
 
 		workPath = util.fsUtil.mkdir(workPath); // 如有重名，会改变

--- a/util/util.js
+++ b/util/util.js
@@ -79,7 +79,6 @@ var fsUtil = {
 	    }
 
 	    fs.mkdirSync(dir);
-	    console.log(dir);
 	    return dir;
     }
 


### PR DESCRIPTION
1. 修改了 `download.js` 为 `dispatch.js` 并移动到了 `/pline` 目录下
2. 将下载文件夹和任务数配置单独存储成配置文件，一次设置永远使用
3. 对自定义下载文件夹功能实现功能补完
